### PR TITLE
Configurable path_prefix for Satellite and OmniAuth

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.draw do
+Satellite::Engine.routes.draw do
   get '/auth/login' => 'satellite/sessions#new', :as => :sign_in
   get '/auth/logout' => 'satellite/sessions#destroy', :as => :sign_out
   get '/auth/:provider/callback' => 'satellite/sessions#create'

--- a/lib/satellite/configuration.rb
+++ b/lib/satellite/configuration.rb
@@ -26,6 +26,10 @@ module Satellite
       AnonymousUser = Class.new{include Satellite::AnonymousUser}
     end
 
+    config_accessor :path_prefix do
+      "/auth"
+    end
+
     def enable_auto_login?
       !!self.enable_auto_login
     end
@@ -63,7 +67,8 @@ module Satellite
     def configure_omniauth!(app)
       config = self
       app.middleware.use OmniAuth::Builder do |builder|
-        provider config.provider, *config.omniauth_args
+        opts = config.omniauth_args.extract_options!
+        provider config.provider, *config.omniauth_args, opts.merge(path_prefix: config.path_prefix)
       end
     end
 

--- a/lib/satellite/controller_extensions.rb
+++ b/lib/satellite/controller_extensions.rb
@@ -28,7 +28,7 @@ module Satellite
     end
 
     def auth_provider_path
-      "/auth/#{Satellite.configuration.provider}"
+      "#{Satellite.path_prefix}/#{Satellite.configuration.provider}"
     end
 
     def authenticate_user!


### PR DESCRIPTION
Allows us to do something like the following in CoPro's `config/initializer/satellite.rb`:

``` ruby
Satellite.configure do |config|
  config.path_prefix = "/teams/auth"
end
```

Probably incomplete because I didn't change Satellite's `config/routes.rb`, but demonstrates most of what I was imagining.
