### PR TITLE
Rely on config host instead on request

### DIFF
--- a/lib/satellite/controller_extensions.rb
+++ b/lib/satellite/controller_extensions.rb
@@ -108,7 +108,8 @@ module Satellite
     end
 
     def root_url_host
-      Rails.application.config.action_controller.default_url_options[:host]
+      default_url_opts = Rails.application.config.action_controller.default_url_options
+      default_url_opts[:host] if default_url_opts
     end
 
     private

--- a/lib/satellite/controller_extensions.rb
+++ b/lib/satellite/controller_extensions.rb
@@ -83,7 +83,6 @@ module Satellite
 
       Addressable::URI.parse(return_to).tap do |url|
         url.scheme = nil
-        url.host = nil
       end.to_s
     end
 

--- a/lib/satellite/controller_extensions.rb
+++ b/lib/satellite/controller_extensions.rb
@@ -46,6 +46,8 @@ module Satellite
 
       if enable_auto_login?
         session[:return_to] = Addressable::URI.parse(request.url).tap do |url|
+          # use configured host instead of request host
+          # prevents redirecting to proxied host
           url.host = root_url_host || request.host
         end.to_s
         redirect_to satellite_refresh_url
@@ -103,6 +105,10 @@ module Satellite
 
     def skip_satellite_authentication
       @skip_satellite_authentication = true
+    end
+
+    def root_url_host
+      Rails.application.config.action_controller.default_url_options[:host]
     end
 
     private

--- a/lib/satellite/version.rb
+++ b/lib/satellite/version.rb
@@ -1,3 +1,3 @@
 module Satellite
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/controllers/controller_extensions_spec.rb
+++ b/spec/controllers/controller_extensions_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe HighVoltage::PagesController, :omniauth do
+  let(:warden) { double(Warden::Proxy, set_user: nil) }
+
+  before do
+    allow(Satellite.configuration).to receive(:enable_auto_login?) { true }
+
+    # allow(warden).to receive(:authenticate!) { create(:user) }
+    allow(warden).to receive(:authenticate) { create(:user) }
+    request.env['warden'] = warden
+    request.env['omniauth.auth'] = mock_auth
+
+    allow(controller).to receive(:user_signed_in?).and_return(false)
+  end
+
+  context "configured domain (proxy configuration)" do
+    before do
+      request.host = "application.herokuapp.com"
+      allow(Rails.application.config.action_controller).to receive(:default_url_options).and_return({ host: "application.com" })
+    end
+
+    it "redirects to the configured domain" do
+      get :show, id: "about"
+      expect(URI.parse(session[:return_to]).host).to eq "application.com"
+    end
+  end
+
+  context "no configured domain" do
+    before do
+      request.host = "application.herokuapp.com"
+    end
+
+    it "redirects to the request domain" do
+      get :show, id: "about"
+      expect(URI.parse(session[:return_to]).host).to eq "application.herokuapp.com"
+    end
+  end
+end

--- a/spec/controllers/satellite/sessions_controller_spec.rb
+++ b/spec/controllers/satellite/sessions_controller_spec.rb
@@ -77,7 +77,7 @@ describe Satellite::SessionsController, :omniauth do
 
       get :refresh
 
-      expect(response).to redirect_to "/teams/devpost"
+      expect(response).to redirect_to "//devpost.com/teams/devpost"
     end
   end
 end


### PR DESCRIPTION
in a configuration like:
user -> nginx proxy -> other host

where nginx set a different host than user requested, Satellite was redirecting to the proxy host instead of the Rails configured host. This will handle this situation now.

I also re-wrote `satellite_refresh_url` in a spirit of better code style
